### PR TITLE
Fix elapsed in log

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    click_house (2.2.0)
+    click_house (2.2.1)
       activesupport
       faraday (>= 2, < 3)
       faraday-http
@@ -9,7 +9,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.1.2)
+    activesupport (8.1.3)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -46,7 +46,7 @@ GEM
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
     hashdiff (1.2.1)
-    http (6.0.1)
+    http (6.0.2)
       http-cookie (~> 1.0)
       llhttp (~> 0.6.1)
     http-cookie (1.1.0)
@@ -65,7 +65,7 @@ GEM
     mcp (0.8.0)
       json-schema (>= 4.1)
     method_source (1.1.0)
-    minitest (6.0.2)
+    minitest (6.0.3)
       drb (~> 2.0)
       prism (~> 1.5)
     net-http (0.9.1)

--- a/lib/click_house/response/summary.rb
+++ b/lib/click_house/response/summary.rb
@@ -7,7 +7,6 @@ module ClickHouse
       KEY_TOTALS = 'totals'
       KEY_STATISTICS = 'statistics'
       KEY_ROWS_BEFORE_LIMIT_AT_LEAST = 'rows_before_limit_at_least'
-      KEY_STAT_ELAPSED = 'elapsed'
 
       attr_reader :config,
                   :headers,
@@ -79,12 +78,12 @@ module ClickHouse
 
       # @return [Float]
       def elapsed
-        statistics[config.key(KEY_STAT_ELAPSED)].to_f
+        summary[config.key('elapsed_ns')].to_f
       end
 
       # @return [String]
       def elapsed_pretty
-        Util::Pretty.measure(elapsed * 1000)
+        Util::Pretty.measure(elapsed / 1000)
       end
 
       private
@@ -98,6 +97,7 @@ module ClickHouse
       #   "total_rows_to_read" => "0",
       #   "result_rows" => "1",
       #   "result_bytes" => "23",
+      #   "elapsed_ns" => "13251725",
       # }
       def parse_summary(value)
         return {} if value.nil? || value.empty?

--- a/lib/click_house/response/summary.rb
+++ b/lib/click_house/response/summary.rb
@@ -7,6 +7,7 @@ module ClickHouse
       KEY_TOTALS = 'totals'
       KEY_STATISTICS = 'statistics'
       KEY_ROWS_BEFORE_LIMIT_AT_LEAST = 'rows_before_limit_at_least'
+      KEY_STAT_ELAPSED = 'elapsed'
 
       attr_reader :config,
                   :headers,
@@ -77,13 +78,17 @@ module ClickHouse
       end
 
       # @return [Float]
-      def elapsed
-        summary[config.key('elapsed_ns')].to_f
+      def elapsed_ms
+        if statistics[config.key(KEY_STAT_ELAPSED)].nil?
+          summary[config.key('elapsed_ns')].to_f * 1000
+        else
+          statistics[config.key(KEY_STAT_ELAPSED)].to_f / 1_000_000
+        end
       end
 
       # @return [String]
       def elapsed_pretty
-        Util::Pretty.measure(elapsed / 1_000_000)
+        Util::Pretty.measure(elapsed_ms)
       end
 
       private

--- a/lib/click_house/response/summary.rb
+++ b/lib/click_house/response/summary.rb
@@ -80,9 +80,9 @@ module ClickHouse
       # @return [Float]
       def elapsed_ms
         if statistics[config.key(KEY_STAT_ELAPSED)].nil?
-          summary[config.key('elapsed_ns')].to_f * 1000
+          summary[config.key('elapsed_ns')].to_f / 1_000_000
         else
-          statistics[config.key(KEY_STAT_ELAPSED)].to_f / 1_000_000
+          statistics[config.key(KEY_STAT_ELAPSED)].to_f * 1000
         end
       end
 

--- a/lib/click_house/response/summary.rb
+++ b/lib/click_house/response/summary.rb
@@ -83,7 +83,7 @@ module ClickHouse
 
       # @return [String]
       def elapsed_pretty
-        Util::Pretty.measure(elapsed / 1000)
+        Util::Pretty.measure(elapsed / 1_000_000)
       end
 
       private

--- a/lib/click_house/version.rb
+++ b/lib/click_house/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ClickHouse
-  VERSION = '2.2.0'
+  VERSION = '2.2.1'
 end


### PR DESCRIPTION
I now parse elapsed_ns from x-clickhouse-summary header.